### PR TITLE
Added additional interesting CIDR ranges from RFC 5735

### DIFF
--- a/hakfindinternaldomains.go
+++ b/hakfindinternaldomains.go
@@ -13,22 +13,28 @@ import (
 func main() {
 	concurrencyPtr := flag.Int("t", 8, "Number of threads to utilise. Default is 8.")
 	flag.Parse()
-	_, cidrA, _ := net.ParseCIDR("10.0.0.0/8")
-	_, cidrB, _ := net.ParseCIDR("172.16.0.0/12")
-	_, cidrC, _ := net.ParseCIDR("192.168.0.0/16")
-	_, cidrD, _ := net.ParseCIDR("0.0.0.0/8")
-	_, cidrE, _ := net.ParseCIDR("127.0.0.0/8")
-	_, cidrF, _ := net.ParseCIDR("169.254.0.0/16")
-	_, cidrG, _ := net.ParseCIDR("192.0.0.0/24")
-	_, cidrH, _ := net.ParseCIDR("192.0.2.0/24")
-	_, cidrI, _ := net.ParseCIDR("192.88.99.0/24")
-	_, cidrJ, _ := net.ParseCIDR("198.18.0.0/15")
-	_, cidrK, _ := net.ParseCIDR("198.51.100.0/24")
-	_, cidrL, _ := net.ParseCIDR("203.0.113.0/24")
-	_, cidrM, _ := net.ParseCIDR("224.0.0.0/4")
-	_, cidrN, _ := net.ParseCIDR("240.0.0.0/4")
-	_, cidrO, _ := net.ParseCIDR("255.255.255.255/32")
-	cidrs := [15]net.IPNet{*cidrA, *cidrB, *cidrC, *cidrD, *cidrE, *cidrF, *cidrG, *cidrH, *cidrI, *cidrJ, *cidrK, *cidrL, *cidrM, *cidrN, *cidrO}
+	cidr_strings := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"0.0.0.0/8",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"192.0.0.0/24",
+		"192.0.2.0/24",
+		"192.88.99.0/24",
+		"198.18.0.0/15",
+		"198.51.100.0/24",
+		"203.0.113.0/24",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		"255.255.255.255/32",
+	}
+	cidrs := make([]net.IPNet, 15)
+	for _, cidr_str := range cidr_strings {
+		_, cidr, _ := net.ParseCIDR(cidr_str)
+		cidrs = append(cidrs, *cidr)
+	}
 
 	work := make(chan string)
 	go func() {
@@ -49,7 +55,7 @@ func main() {
 	wg.Wait()
 }
 
-func doWork(work chan string, wg *sync.WaitGroup, cidrs [15]net.IPNet) {
+func doWork(work chan string, wg *sync.WaitGroup, cidrs []net.IPNet) {
 	defer wg.Done()
 	for text := range work {
 		ip, err := net.LookupIP(text)

--- a/hakfindinternaldomains.go
+++ b/hakfindinternaldomains.go
@@ -13,22 +13,23 @@ import (
 func main() {
 	concurrencyPtr := flag.Int("t", 8, "Number of threads to utilise. Default is 8.")
 	flag.Parse()
+	// Taken from https://datatracker.ietf.org/doc/html/rfc5735
 	cidr_strings := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
-		"0.0.0.0/8",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"192.0.0.0/24",
-		"192.0.2.0/24",
-		"192.88.99.0/24",
-		"198.18.0.0/15",
-		"198.51.100.0/24",
-		"203.0.113.0/24",
-		"224.0.0.0/4",
-		"240.0.0.0/4",
-		"255.255.255.255/32",
+		"0.0.0.0/8",          // "This" Network RFC 1122, Section 3.2.1.3
+		"10.0.0.0/8",         // Private-Use Networks RFC 1918
+		"127.0.0.0/8",        // Loopback RFC 1122, Section 3.2.1.3
+		"169.254.0.0/16",     // Link Local RFC 3927
+		"172.16.0.0/12",      // Private-Use Networks RFC 1918
+		"192.0.0.0/24",       // IETF Protocol Assignments RFC 5736
+		"192.0.2.0/24",       // TEST-NET-1 RFC 5737
+		"192.88.99.0/24",     // 6to4 Relay Anycast RFC 3068
+		"192.168.0.0/16",     // Private-Use Networks RFC 1918
+		"198.18.0.0/15",      // Network Interconnect
+		"198.51.100.0/24",    // TEST-NET-2 RFC 5737
+		"203.0.113.0/24",     // TEST-NET-3 RFC 5737
+		"224.0.0.0/4",        // Multicast RFC 3171
+		"240.0.0.0/4",        // Reserved for Future Use RFC 1112, Section 4
+		"255.255.255.255/32", // Limited Broadcast RFC 919, Section 7
 	}
 	cidrs := make([]net.IPNet, 15)
 	for _, cidr_str := range cidr_strings {

--- a/hakfindinternaldomains.go
+++ b/hakfindinternaldomains.go
@@ -16,7 +16,19 @@ func main() {
 	_, cidrA, _ := net.ParseCIDR("10.0.0.0/8")
 	_, cidrB, _ := net.ParseCIDR("172.16.0.0/12")
 	_, cidrC, _ := net.ParseCIDR("192.168.0.0/16")
-	cidrs := [3]net.IPNet{*cidrA, *cidrB, *cidrC}
+	_, cidrD, _ := net.ParseCIDR("0.0.0.0/8")
+	_, cidrE, _ := net.ParseCIDR("127.0.0.0/8")
+	_, cidrF, _ := net.ParseCIDR("169.254.0.0/16")
+	_, cidrG, _ := net.ParseCIDR("192.0.0.0/24")
+	_, cidrH, _ := net.ParseCIDR("192.0.2.0/24")
+	_, cidrI, _ := net.ParseCIDR("192.88.99.0/24")
+	_, cidrJ, _ := net.ParseCIDR("198.18.0.0/15")
+	_, cidrK, _ := net.ParseCIDR("198.51.100.0/24")
+	_, cidrL, _ := net.ParseCIDR("203.0.113.0/24")
+	_, cidrM, _ := net.ParseCIDR("224.0.0.0/4")
+	_, cidrN, _ := net.ParseCIDR("240.0.0.0/4")
+	_, cidrO, _ := net.ParseCIDR("255.255.255.255/32")
+	cidrs := [15]net.IPNet{*cidrA, *cidrB, *cidrC, *cidrD, *cidrE, *cidrF, *cidrG, *cidrH, *cidrI, *cidrJ, *cidrK, *cidrL, *cidrM, *cidrN, *cidrO}
 
 	work := make(chan string)
 	go func() {
@@ -37,7 +49,7 @@ func main() {
 	wg.Wait()
 }
 
-func doWork(work chan string, wg *sync.WaitGroup, cidrs [3]net.IPNet) {
+func doWork(work chan string, wg *sync.WaitGroup, cidrs [15]net.IPNet) {
 	defer wg.Done()
 	for text := range work {
 		ip, err := net.LookupIP(text)


### PR DESCRIPTION
There are some CIDRs that I've found useful before, particularly link local and loopback, that were missing prior to this PR. I decided to add all of the CIDRs specified in RFC 5735 though because if a company had a DNS entry pointing to them, they're probably doing something worth looking into.

If you'd like me to add/remove CIDRs or put the additional CIDRs behind a flag, let me know and I can update the PR.